### PR TITLE
lock eventlet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests==2.25.1
 flask==2.0.1
 gunicorn==20.1.0
 pyopenssl==20.0.1
-eventlet
+eventlet==0.31.2
 prometheus_client


### PR DESCRIPTION
Eventlet broken in gunicorn until https://github.com/benoitc/gunicorn/pull/2581 is fixed.