### PR TITLE
enable multiprocess metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM python:3.7-slim
 
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp/metric-multi
+RUN mkdir -p /tmp/metric-multi
+
 ENV PATH="/venv/bin:$PATH"
 RUN python3 -m venv /venv
 
 COPY requirements.txt /app/requirements.txt
 RUN pip install -r /app/requirements.txt
+COPY gunicorn.conf.py /app/gunicorn.conf.py
 COPY am2alertapi.py /app/am2alertapi.py
 
-ENTRYPOINT ["gunicorn", "app.am2alertapi:server", "-b", ":3080", \
+ENTRYPOINT ["gunicorn", "app.am2alertapi:server", "-b", ":3080", "-c", "/app/gunicorn.conf.py", \
             "--worker-class=eventlet", "--workers=3", "--log-level", "INFO"]
 
 # With Apache style request logging

--- a/am2alertapi.py
+++ b/am2alertapi.py
@@ -63,9 +63,9 @@ loginfo('config org="{0}"'.format(ci_organization))
 
 server = Flask(__name__)
 
+response_count = Counter('am2alertapi_responses_total', 'HTTP responses', ['api_endpoint', 'status_code'])
 registry = CollectorRegistry()
 multiprocess.MultiProcessCollector(registry)
-response_count = Counter('am2alertapi_responses_total', 'HTTP responses', ['api_endpoint', 'status_code'], registry=registry)
 
 def translate(amalert):
     results = []

--- a/am2alertapi.py
+++ b/am2alertapi.py
@@ -162,13 +162,13 @@ def watchdog():
         try:
             api_response = requests.post(keepalive_endpoint, headers=headers, data=json_alert, timeout=10)
         except requests.exceptions.Timeout:
-            logerror('timeout with alertAPI')
+            logerror('timeout with alertAPI keepalive')
             response_count.labels(api_endpoint='/watchdog', status_code='500').inc()
-            abort(500, description="timeout with alertapi")
+            abort(500, description="timeout with alertapi keepalive")
         except ConnectionError:
-            logerror('connect error with alertAPI')
+            logerror('connect error with alertAPI keepalive')
             response_count.labels(api_endpoint='/watchdog', status_code='500').inc()
-            abort(500, description="connect error with alertapi")
+            abort(500, description="connect error with alertapi keepalive")
         else:
             loginfo('keepalive {}:{} urgency {} timeout {} return_code {}'.format(alert['ci']['name'], 
                 alert['component']['name'], alert['urgency'], alert['timeout'], api_response.status_code))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,0 @@
-steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/am2alertapi:$TAG_NAME', '.' ]
-images: ['gcr.io/$PROJECT_ID/am2alertapi']

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,5 @@
+from prometheus_client import multiprocess
+
+def child_exit(server, worker):
+    multiprocess.mark_process_dead(worker.pid)
+    

--- a/run_locally
+++ b/run_locally
@@ -1,8 +1,13 @@
 # SOURCE this to run locally on your dev machine
 
-virtualenv -p python3 `pwd`/app
-export VIRTUAL_ENV=`pwd`/app
-export PATH=`pwd`/app/bin:$PATH
+export PROMETHEUS_MULTIPROC_DIR=/tmp/metric-multi
+rm -rf /tmp/metric-multi; mkdir -p /tmp/metric-multi
+
+if [ ! -d /app ]; then
+  virtualenv -p python3 `pwd`/app
+  export VIRTUAL_ENV=`pwd`/app
+  export PATH=`pwd`/app/bin:$PATH
+fi
 
 # use mci test token here
 export ALERTAPI_TOKEN=YOUR TOKEN
@@ -10,8 +15,10 @@ export ALERTAPI_URL=https://api.alerts-test.s.uw.edu
 export ALERT_ORGANIZATION="UW-IT"
 
 cd app
+pip install --upgrade pip
 pip install -r ../requirements.txt
-ln -s ../am2alertapi.py
+ln -s ../gunicorn.conf.py
+ln -sf ../am2alertapi.py
 cd ..
-gunicorn app.am2alertapi:server -b 127.0.0.1:3080 --worker-class=eventlet --workers=3 --log-level DEBUG
+gunicorn app.am2alertapi:server -b 127.0.0.1:3080 -c app/gunicorn.conf.py --worker-class=eventlet --workers=3 --log-level DEBUG
 

--- a/run_locally
+++ b/run_locally
@@ -13,5 +13,5 @@ cd app
 pip install -r ../requirements.txt
 ln -s ../am2alertapi.py
 cd ..
-gunicorn app.am2alertapi:server -b 127.0.0.1:3080 --worker-class=eventlet --log-level DEBUG
+gunicorn app.am2alertapi:server -b 127.0.0.1:3080 --worker-class=eventlet --workers=3 --log-level DEBUG
 


### PR DESCRIPTION
Using multiple workers results in independent metrics for each process. Introduce multiprocess mode in prometheus_client.
Implements https://github.com/UWIT-UE/am2alertapi/issues/22