### PR TITLE
Update requirements.txt with flask dependency version lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 httpx==0.24.1
 quart==0.18.4
+Werkzeug==2.2.2
 prometheus-client


### PR DESCRIPTION
Recommend including a specific package version for a dependency of flask, due to a bad dependency specification in Pypi. 

https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr

```
>>> from quart import Quart, Response, request, abort, jsonify
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/venv/lib/python3.10/site-packages/quart/__init__.py", line 5, in <module>
    from .app import Quart as Quart
  File "/venv/lib/python3.10/site-packages/quart/app.py", line 46, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/venv/lib/python3.10/site-packages/werkzeug/urls.py)
```