### PR TITLE
am2alertapi: v2 API expects integer timeout

### DIFF
--- a/am2alertapi.py
+++ b/am2alertapi.py
@@ -110,7 +110,7 @@ def translate(amalert):
                 result['urgency'] = 'OK'
 
             if alert['labels'].get('watchdog_timeout'):
-                result['timeout'] = alert['labels']['watchdog_timeout']
+                result['timeout'] = int(alert['labels']['watchdog_timeout'])
 
             results.append(result)
 


### PR DESCRIPTION
New API is true to documentation and requires keepalive timeout value to be provided as an integer in the payload. The old API was forgiving.